### PR TITLE
update migration notes and config

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           pandoc-version: "2.10"
 
+      - name: setup libgit2
+        run: brew install libgit2
+
       - name: Cache R packages
         uses: actions/cache@v2
         with:

--- a/config.yaml
+++ b/config.yaml
@@ -7,26 +7,26 @@
 # dc: Data Carpentry
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
-carpentry: cp
+carpentry: swc 
 
 # Overall title for pages.
-title: Lesson Title
+title: Programming With R
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: pre-alpha
+life_cycle: alpha
 
 # License of the lesson
 license: CC-BY 4.0
 
 # Link to the source repository for this lesson
-source: https://github.com/carpentries/sandpaper
+source: https://github.com/zkamvar/new-programming-with-r
 
 # Default branch of your lesson
 branch: main
 
 # Who to contact if there are any issues
-contact: team@carpentries.org
+contact: zkamvar@carpentries.org
 
 # Navigation ------------------------------------------------
 # The menu bar will be in the following order:

--- a/instructors/migration-notes.md
+++ b/instructors/migration-notes.md
@@ -62,4 +62,27 @@ fs::dir_copy(fs::path(src, "_episodes_rmd/data/", "episodes/"))
 rscripts <- fs::dir_ls(fs::path(src, "r-novice-gapminder/_episodes_rmd/"), glob = "*.R") 
 fs::file_copy(rscripts, "episodes/", overwrite = TRUE)
 fs::file_delete("episodes/01-introduction.Rmd")
+fs::file_delete("learners/Setup.md")
 ```
+
+After this was done, I added the `.github/` configuration files from https://github.com/zkamvar/testme. I then ran `sandpaper::build_lesson()` to test that it worked (there's something going on with the formatting, but nothing need be changed on this end). 
+
+I then used the following steps to update the config file
+
+
+```r
+library("sandpaper")
+# set the order of the learner files
+learn <- get_learners()
+set_learners(order = learn, write = TRUE)
+
+# set the order of the episode files
+ep <- get_episodes()
+set_episodes(order = ep, write = TRUE)
+```
+
+I ran into [a bug with {sandpaper}](https://github.com/carpentries/sandpaper/issues/53) that will be fixed soon, but it luckily does not affect the results.
+
+I committed all the bits and pushed the results to github where everything was able to install (after I made sure the dependencies were taken care of). 
+
+At this moment, I am finishing up the notes for the migration and setting up the configuration file.


### PR DESCRIPTION
I've added to the migration notes and the config file, which should change the appearance, but won't affect the main content other than having a software carpentry logo

This also edits the git config file so we won't see any new branch created from this.